### PR TITLE
Added automatic VSIX packaging via GitHub Actions

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,0 +1,23 @@
+on:
+    push:
+      branches:
+        - master
+name: Release
+jobs:
+    package:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - run: npm install
+        - uses: lannonbr/vsce-action@3.0.0
+          with:
+            args: "pack"
+        - uses: "marvinpinto/action-automatic-releases@latest"
+          with:
+            repo_token: "${{ secrets.GITHUB_TOKEN }}"
+            automatic_release_tag: "master"
+            prerelease: true
+            title: "master branch development build"
+            files: |
+              LICENSE
+              *.vsix

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -11,7 +11,7 @@ jobs:
         - run: npm install
         - uses: lannonbr/vsce-action@3.0.0
           with:
-            args: "pack"
+            args: "package"
         - uses: "marvinpinto/action-automatic-releases@latest"
           with:
             repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
It is pretty bare-bones for now, as I'm not sure how to extract version number from package.json reliably, but should be just enough to share straight from master branch to people who don't have node+vsce setup on hand, for testing and feedback.

Also, TIL "pack" was not always a command keyword, so I corrected that to "package", and now it works.